### PR TITLE
add test for get_cell on non-existent cell, fix code

### DIFF
--- a/lib/xlsxir.ex
+++ b/lib/xlsxir.ex
@@ -358,12 +358,13 @@ defmodule Xlsxir do
   defp do_get_cell(cell_ref, table_id \\ :worksheet) do
     [[row_num]] = ~r/\d+/ |> Regex.scan(cell_ref)
     row_num     = row_num |> String.to_integer
-    [[row]]     = :ets.match(table_id, {row_num, :"$1"})
-
-    row
-    |> Enum.filter(fn [ref, _val] -> ref == cell_ref end)
-    |> List.first
-    |> Enum.at(1)
+    case :ets.match(table_id, {row_num, :"$1"}) do
+      [[row]] -> row
+                  |> Enum.filter(fn [ref, _val] -> ref == cell_ref end)
+                  |> List.first
+                  |> Enum.at(1)
+      _       -> nil
+    end
   end
 
   @doc """

--- a/test/xlsxir_test.exs
+++ b/test/xlsxir_test.exs
@@ -53,4 +53,10 @@ defmodule XlsxirTest do
     assert get_info(:rows) == 10
     close()
   end
+
+  test "get_cell returns nil for non-existent cells" do
+    extract(path(), 3)
+    assert get_cell("A1") == nil
+    close()
+  end
 end


### PR DESCRIPTION
I'm not sure if this is the right solution to my problem. I am trying to read from multiple worksheets to see if I can find the right one (checking a value in "A1"). But if I try and look at a sheet that has no such cell then the app errors with:

```
     ** (MatchError) no match of right hand side value: []
     stacktrace:
       (xlsxir) lib/xlsxir.ex:361: Xlsxir.do_get_cell/2
```

For my needs it is adequate that `get_cell` returns `nil` for a non-existent cell. This PR has a test and changes that handle this.

Please advise if there is an alternative approach, or, should this change be acceptable, what, if anything, else should be done to make this PR suitable for merging.

Thanks for the lib, BTW.
