### PR TITLE
Add a stream_list method that streams rows without loading the rows in ETS 

### DIFF
--- a/lib/xlsxir.ex
+++ b/lib/xlsxir.ex
@@ -119,6 +119,8 @@ defmodule Xlsxir do
   ## Example
   Extract first worksheet in an example file named `test.xlsx` located in `./test/test_data`:
 
+        iex> with %Stream{} <- Xlsxir.stream_list("./test/test_data/test.xlsx", 1), do: true
+        true
         iex> Xlsxir.stream_list("./test/test_data/test.xlsx", 1) |> Enum.take(1)
         [[1, 2]]
         iex> Xlsxir.stream_list("./test/test_data/test.xlsx", 1) |> Enum.take(3)

--- a/lib/xlsxir/parse_worksheet.ex
+++ b/lib/xlsxir/parse_worksheet.ex
@@ -24,7 +24,7 @@ defmodule Xlsxir.ParseWorksheet do
     %__MODULE__{tid: GenServer.call(Xlsxir.StateManager, :new_table), max_rows: max_rows}
   end
 
-  def sax_event_handler({:startElement,_,'row',_,_}, %__MODULE__{tid: tid, max_rows: max_rows}, _excel) do
+  def sax_event_handler({:startElement,_,'row',_,_}, %{tid: tid, max_rows: max_rows}, _excel) do
     %__MODULE__{tid: tid, max_rows: max_rows}
   end
 
@@ -52,12 +52,12 @@ defmodule Xlsxir.ParseWorksheet do
     if state == nil, do: nil, else: %{state | value: value}
   end
 
-  def sax_event_handler({:endElement,_,'c',_}, %__MODULE__{row: row} = state, %Xlsxir{} = excel) do
+  def sax_event_handler({:endElement,_,'c',_}, %{row: row} = state, %Xlsxir{} = excel) do
     cell_value = format_cell_value(excel, [state.data_type, state.num_style, state.value])
     %{state | row: Enum.into(row, [[to_string(state.cell_ref), cell_value]]), cell_ref: "", data_type: "", num_style: "", value: ""}
   end
 
-  def sax_event_handler({:endElement,_,'row',_}, %__MODULE__{tid: tid, max_rows: max_rows} = state, _excel) do
+  def sax_event_handler({:endElement,_,'row',_}, %{tid: tid, max_rows: max_rows} = state, _excel) do
     unless Enum.empty?(state.row) do
       [[row]] = ~r/\d+/ |> Regex.scan(state.row |> List.first |> List.first)
       row     = row |> String.to_integer

--- a/lib/xlsxir/sax_parser.ex
+++ b/lib/xlsxir/sax_parser.ex
@@ -4,7 +4,7 @@ defmodule Xlsxir.SaxParser do
   parsing algorithm for parsing large XML files in chunks, preventing the need to load the entire DOM into memory. Current chunk size is set to 10,000.
   """
 
-  alias Xlsxir.{ParseString, ParseStyle, ParseWorksheet, SaxError}
+  alias Xlsxir.{ParseString, ParseStyle, ParseWorksheet, StreamWorksheet, SaxError}
   require Logger
 
   @chunk 10000
@@ -50,6 +50,7 @@ defmodule Xlsxir.SaxParser do
         nil,
         case type do
           :worksheet -> &(ParseWorksheet.sax_event_handler(&1, &2, excel))
+          :stream_worksheet -> &(StreamWorksheet.sax_event_handler(&1, &2, excel))
           :style     -> &(ParseStyle.sax_event_handler(&1, &2))
           :string    -> &(ParseString.sax_event_handler(&1, &2))
           _          -> raise "Invalid file type for sax_event_handler/2"
@@ -68,5 +69,4 @@ defmodule Xlsxir.SaxParser do
       :eof        -> {tail, {pid, offset, chunk}}
     end
   end
-
 end

--- a/lib/xlsxir/sax_parser.ex
+++ b/lib/xlsxir/sax_parser.ex
@@ -4,13 +4,13 @@ defmodule Xlsxir.SaxParser do
   parsing algorithm for parsing large XML files in chunks, preventing the need to load the entire DOM into memory. Current chunk size is set to 10,000.
   """
 
-  alias Xlsxir.{ParseString, ParseStyle, ParseWorksheet, StreamWorksheet, SaxError}
+  alias Xlsxir.{ParseString, ParseStyle, ParseWorksheet, StreamWorksheet, SaxError, XmlFile}
   require Logger
 
   @chunk 10000
 
   @doc """
-  Parses `xl/worksheets/sheet\#{n}.xml` at index `n`, `xl/styles.xml` and `xl/sharedStrings.xml` using SAX parsing. An Erlang Term Storage (ETS) process is started to hold the state of data
+  Parses `XmlFile` (`xl/worksheets/sheet\#{n}.xml` at index `n`, `xl/styles.xml` or `xl/sharedStrings.xml`) using SAX parsing. An Erlang Term Storage (ETS) process is started to hold the state of data
   parsed. The style and sharedstring XML files (if they exist) must be parsed first in order for the worksheet parser to sucessfully complete.
 
   ## Parameters
@@ -29,18 +29,18 @@ defmodule Xlsxir.SaxParser do
     The `.xlsx` file contents have been extracted to `./test/test_data/test`. For purposes of this example, we utilize the `get_at/1` function of each ETS process module to pull a sample of the parsed
     data. Keep in mind that the worksheet data is stored in the ETS process as a list of row lists, so the `Xlsxir..get_row/2` function will return a full row of values.
 
-          iex> {:ok, %Xlsxir.ParseStyle{tid: tid1}, _} = Xlsxir.SaxParser.parse(File.read!("./test/test_data/test/xl/styles.xml"), :style)
+          iex> {:ok, %Xlsxir.ParseStyle{tid: tid1}, _} = Xlsxir.SaxParser.parse(%Xlsxir.XmlFile{content: File.read!("./test/test_data/test/xl/styles.xml")}, :style)
           iex> :ets.lookup(tid1, 0)
           [{0, nil}]
-          iex> {:ok, %Xlsxir.ParseString{tid: tid2}, _} = Xlsxir.SaxParser.parse(File.read!("./test/test_data/test/xl/sharedStrings.xml"), :string)
+          iex> {:ok, %Xlsxir.ParseString{tid: tid2}, _} = Xlsxir.SaxParser.parse(%Xlsxir.XmlFile{content: File.read!("./test/test_data/test/xl/sharedStrings.xml")}, :string)
           iex> :ets.lookup(tid2, 0)
           [{0, "string one"}]
-          iex> {:ok, %Xlsxir.ParseWorksheet{tid: tid3}, _} = Xlsxir.SaxParser.parse(File.read!("./test/test_data/test/xl/worksheets/sheet1.xml"), :worksheet, %Xlsxir{shared_strings: tid2, styles: tid1})
+          iex> {:ok, %Xlsxir.ParseWorksheet{tid: tid3}, _} = Xlsxir.SaxParser.parse(%Xlsxir.XmlFile{content: File.read!("./test/test_data/test/xl/worksheets/sheet1.xml")}, :worksheet, %Xlsxir{shared_strings: tid2, styles: tid1})
           iex> :ets.lookup(tid3, 1)
           [{1, [["A1", "string one"], ["B1", "string two"], ["C1", 10], ["D1", 20], ["E1", {2016, 1, 1}]]}]
   """
-  def parse(content, type, excel \\ nil) do
-    {:ok, file_pid} = File.open(content, [:binary, :ram])
+  def parse(%XmlFile{} = xml_file, type, excel \\ nil) do
+    {:ok, file_pid} = XmlFile.open(xml_file)
 
     index   = 0
     c_state = {file_pid, index, @chunk}
@@ -49,17 +49,17 @@ defmodule Xlsxir.SaxParser do
       :erlsom.parse_sax("",
         nil,
         case type do
-          :worksheet -> &(ParseWorksheet.sax_event_handler(&1, &2, excel))
+          :worksheet        -> &(ParseWorksheet.sax_event_handler(&1, &2, excel))
           :stream_worksheet -> &(StreamWorksheet.sax_event_handler(&1, &2, excel))
-          :style     -> &(ParseStyle.sax_event_handler(&1, &2))
-          :string    -> &(ParseString.sax_event_handler(&1, &2))
-          _          -> raise "Invalid file type for sax_event_handler/2"
+          :style            -> &(ParseStyle.sax_event_handler(&1, &2))
+          :string           -> &(ParseString.sax_event_handler(&1, &2))
+          _                 -> raise "Invalid file type for sax_event_handler/2"
         end,
         [{:continuation_function, &continue_file/2, c_state}])
     rescue e in SaxError ->
       {:ok, e.state, []}
-      after
-        File.close(file_pid)
+    after
+      File.close(file_pid)
     end
   end
 

--- a/lib/xlsxir/stream_worksheet.ex
+++ b/lib/xlsxir/stream_worksheet.ex
@@ -1,0 +1,61 @@
+defmodule Xlsxir.StreamWorksheet do
+  @moduledoc """
+  Holds the special SAX event instructions for parsing and streaming
+  worksheet data rows via `Xlsxir.SaxParser.parse/2`
+
+  Delegates other SAX event instructions to `Xlsxir.ParseWorksheet`
+  """
+
+  alias Xlsxir.ParseWorksheet
+
+  @doc """
+  Sax event utilized by `Xlsxir.SaxParser.parse/2`.
+
+  Takes a pattern and the current state of a struct and recursivly parses the
+  worksheet XML file.
+
+  Blocks the process when a row is fully parsed, with cell references
+  and their assocated values, then wait for a message from a parent process
+  to callback and send the row data.
+
+  ## Parameters
+
+  - `sax_pattern` - the XML pattern of the event to match upon
+  - `state` - the state of the `%Xlsxir.StreamWorksheet{}` struct which temporarily holds applicable data of the current row being parsed
+
+  ## Example
+
+  Each row data sent consists of a list containing a cell reference string
+  and the associated value (i.e. `[["A1", "string one"], ...]`).
+  """
+  def sax_event_handler(sax_pattern, state, excel)
+
+  def sax_event_handler(:startDocument, _state, %Xlsxir{}) do
+    %ParseWorksheet{}
+  end
+
+  def sax_event_handler({:endElement,_,'row',_}, state, _excel) do
+    unless Enum.empty?(state.row) do
+      value = state.row |> Enum.reverse
+
+      # Wait for parent process to ask for the next row
+      receive do
+        {:get_next_row, from} -> send(from, {:next_row, value})
+      end
+    end
+    state
+  end
+
+  def sax_event_handler(:endDocument, _state, _excel) do
+    # If the end of the document is reached, and if the
+    # parent process ask for a next row, sends the `end` message
+    receive do
+      {:get_next_row, from} -> send(from, {:end})
+    end
+  end
+
+  # Delegates other SAX events to Xlsxir.ParseWorksheet
+  def sax_event_handler(sax_event, state, excel) do
+    ParseWorksheet.sax_event_handler(sax_event, state, excel)
+  end
+end

--- a/lib/xlsxir/unzip.ex
+++ b/lib/xlsxir/unzip.ex
@@ -1,7 +1,10 @@
 defmodule Xlsxir.Unzip do
 
+  alias Xlsxir.XmlFile
+
   @moduledoc """
-  Provides validation of accepted file types for file path, extracts required `.xlsx` contents to memory.
+  Provides validation of accepted file types for file path, extracts required `.xlsx` contents to memory
+  or `./temp` (and ultimately deletes the `./temp` directory and its contents).
   """
   @filetype_error "Invalid file type (expected xlsx)."
   @xml_not_found_error "Invalid File. Required XML files not found."
@@ -127,30 +130,53 @@ defmodule Xlsxir.Unzip do
     ]
   end
 
+
   @doc """
-  Extracts requested list of files from a `.zip` file to memory and returns a list of the extracted file paths.
+  Extracts requested list of files from a `.zip` file to memory or file system
+  and returns a list of the extracted file paths.
 
   ## Parameters
 
   - `file_list` - list containing file paths to be extracted in `char_list` format
   - `path` - file path of a `.xlsx` file type in `string` format
+  - `to` - `:memory` or `:file` option
 
   ## Example
   An example file named `test.zip` located in './test_data/test' containing a single file named `test.txt`:
 
       iex> path = "./test/test_data/test.zip"
       iex> file_list = ['test.txt']
-      iex> Xlsxir.Unzip.extract_xml_to_memory(file_list, path)
-      {:ok, [{'test.txt', "test_successful"}]}
+      iex> Xlsxir.Unzip.extract_xml(file_list, path, :memory)
+      {:ok, [%Xlsxir.XmlFile{content: "test_successful", name: "test.txt", path: nil}]}
+      iex> Xlsxir.Unzip.extract_xml(file_list, path, :file)
+      {:ok, [%Xlsxir.XmlFile{content: nil, name: "test.txt", path: "temp/test.txt"}]}
   """
-  def extract_xml_to_memory(file_list, path) do
+  def extract_xml(file_list, path, to) do
     path
     |> to_char_list
-    |> :zip.extract([{:file_list, file_list}, :memory])
+    |> extract_from_zip(file_list, to)
     |> case do
         {:error, reason}  -> {:error, reason}
         {:ok, []}         -> {:error, @xml_not_found_error}
-        {:ok, files_list} -> {:ok, files_list}
+        {:ok, files_list} -> {:ok, build_xml_files(files_list)}
        end
+  end
+
+  defp extract_from_zip(path, file_list, :memory), do: :zip.extract(path, [{:file_list, file_list}, :memory])
+  defp extract_from_zip(path, file_list, :file), do: :zip.extract(path, [{:file_list, file_list}, {:cwd, 'temp/'}])
+
+  defp build_xml_files(files_list) do
+    files_list
+    |> Enum.map(&build_xml_file/1)
+  end
+
+  # When extracting to memory
+  defp build_xml_file({name, content}) do
+    %XmlFile{name: Path.basename(name), content: content}
+  end
+
+  # When extracting to temp file
+  defp build_xml_file(file_path) do
+    %XmlFile{name:  Path.basename(file_path), path: to_string(file_path)}
   end
 end

--- a/lib/xlsxir/xml_file.ex
+++ b/lib/xlsxir/xml_file.ex
@@ -1,0 +1,22 @@
+defmodule Xlsxir.XmlFile do
+  @moduledoc """
+  Struct that represents an XML file extracted from an `xlsx` file,
+  either in memory (in the `content` field) or on the filesystem
+  (located in the `path` field)
+  """
+
+  defstruct [name: nil, path: nil, content: nil]
+
+  @doc """
+  Open an XmlFile
+
+  ## Parameters
+  - `xml_file` - xml file to open
+  """
+  def open(%__MODULE__{} = xml_file) do
+    case Map.get(xml_file, :content, nil) do
+      nil -> File.open(xml_file.path, [:binary])
+      content -> File.open(content, [:binary, :ram])
+    end
+  end
+end

--- a/test/sax_parser_test.exs
+++ b/test/sax_parser_test.exs
@@ -2,9 +2,11 @@ defmodule SaxParserTest do
   use ExUnit.Case
 
   alias Xlsxir.SaxParser
+  alias Xlsxir.XmlFile
 
   test "reads complex shared strings correctly" do
-    {:ok, %{tid: tid}, _} = SaxParser.parse(File.read!("./test/test_data/complexStrings.xml"), :string)
+    xml_file = %XmlFile{content: File.read!("./test/test_data/complexStrings.xml")}
+    {:ok, %{tid: tid}, _} = SaxParser.parse(xml_file, :string)
 
     assert find_string(tid, 0) == "FOO: BAR"
     assert find_string(tid, 1) == "BAZ"

--- a/test/xlsxir_test.exs
+++ b/test/xlsxir_test.exs
@@ -70,7 +70,5 @@ defmodule XlsxirTest do
 
   test "stream_list returns a stream of rows" do
     assert %Stream{} = stream_list(path(), 1)
-    assert stream_list(path(), 1) |> Enum.take(1) == [[1, 2]]
-    assert stream_list(path(), 1) |> Enum.take(3) == [[1, 2], [3, 4]]
   end
 end

--- a/test/xlsxir_test.exs
+++ b/test/xlsxir_test.exs
@@ -67,4 +67,10 @@ defmodule XlsxirTest do
     assert get_cell(pid, "A2") == "Data"
     close(pid)
   end
+
+  test "stream_list returns a stream of rows" do
+    assert %Stream{} = stream_list(path(), 1)
+    assert stream_list(path(), 1) |> Enum.take(1) == [[1, 2]]
+    assert stream_list(path(), 1) |> Enum.take(3) == [[1, 2], [3, 4]]
+  end
 end

--- a/test/xlsxir_test.exs
+++ b/test/xlsxir_test.exs
@@ -67,8 +67,4 @@ defmodule XlsxirTest do
     assert get_cell(pid, "A2") == "Data"
     close(pid)
   end
-
-  test "stream_list returns a stream of rows" do
-    assert %Stream{} = stream_list(path(), 1)
-  end
 end

--- a/test/xml_file_test.exs
+++ b/test/xml_file_test.exs
@@ -1,0 +1,11 @@
+defmodule XmlFileTest do
+  use ExUnit.Case
+
+  test "open memory XmlFile" do
+    assert {:ok, _file_pid} = Xlsxir.XmlFile.open(%Xlsxir.XmlFile{content: File.read!("./test/test_data/test/xl/styles.xml")})
+  end
+
+  test "open filepath XmlFile" do
+    assert {:ok, _file_pid} = Xlsxir.XmlFile.open(%Xlsxir.XmlFile{path: "./test/test_data/test/xl/styles.xml"})
+  end
+end


### PR DESCRIPTION
I had a memory problem with a huge file I need to parse (40k lines, > 100 columns), and it kept crashing my server... so I tried to implement the suggestion made by @AlexKovalevych in this issue : https://github.com/jsonkennell/xlsxir/issues/51

This PR adds a `Xslxir.stream_list/2` method that returns a `Stream` without loading the entire list of rows into an ETS table. 

I tried a few different things, but in the end I only managed to get this working by running an independant process doing the SAX parsing that "blocks" until the stream process ask for next row.

thanks for this lib btw :)