### PR TITLE
Streaming method and extract to memory or files option

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -28,3 +28,5 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env}.exs"
+
+# config :xlsxir, extract_base_dir: "temp"

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,31 +2,6 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
-
-# You can configure for your application as:
-#
-#     config :xlsxir, key: :value
-#
-# And access this configuration in your application as:
-#
-#     Application.get_env(:xlsxir, :key)
-#
-# Or configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
-
+# when extracting to file, files will be extracted
+# in a sub directory in the `:extract_base_dir` directory.
 # config :xlsxir, extract_base_dir: "temp"

--- a/lib/xlsxir.ex
+++ b/lib/xlsxir.ex
@@ -101,6 +101,14 @@ defmodule Xlsxir do
   - `path` - file path of a `.xlsx` file type in `string` format
   - `index` - index of worksheet from within the Excel workbook to be parsed (zero-based index)
 
+  ## Options
+  - `:extract_to` - Specify how the `.xlsx` content (i.e. sharedStrings.xml,
+     style.xml and worksheets xml files) will be be extracted before being parsed.
+    `:memory` will extract files to memory, and `:file` to files in the file system
+  - `:extract_base_dir` - when extracting to file, files will be extracted
+     in a sub directory in the `:extract_base_dir` directory. Defaults to
+     `Application.get_env(:xlsxir, :extract_base_dir)` or "temp"
+
   ## Example
   Extract first worksheet in an example file named `test.xlsx` located in `./test/test_data`:
 
@@ -109,14 +117,14 @@ defmodule Xlsxir do
         iex> Xlsxir.stream_list("./test/test_data/test.xlsx", 1) |> Enum.take(3)
         [[1, 2], [3, 4]]
   """
-  def stream_list(path, index) do
-    stream(path, index)
+  def stream_list(path, index, options \\ []) do
+    stream(path, index, options)
     |> Stream.map(&row_data_to_list/1)
   end
 
-  defp stream(path, index) do
+  defp stream(path, index, options) do
     path
-    |> XlsxFile.initialize([extract_to: :file])
+    |> XlsxFile.initialize(Keyword.merge([extract_to: :file], options))
     |> XlsxFile.stream(index)
   end
 

--- a/lib/xlsxir.ex
+++ b/lib/xlsxir.ex
@@ -66,6 +66,13 @@ defmodule Xlsxir do
         iex> Xlsxir.close(tid2)
         :ok
 
+  ## Example (errors)
+
+        iex> Xlsxir.extract("./test/test_data/test.invalidfile", 0)
+        {:error, "Invalid file type (expected xlsx)."}
+
+        iex> Xlsxir.extract("./test/test_data/test.xlsx", 100)
+        {:error, "Invalid worksheet index."}
   """
   def extract(path, index, timer \\ false, options \\ []) do
     xlsx_file = XlsxFile.initialize(path, options)
@@ -175,6 +182,14 @@ defmodule Xlsxir do
         true
         iex> Enum.map(results, fn {:ok, tid, _timer} -> Xlsxir.close(tid) end) |> Enum.all?(fn result -> result == :ok end)
         true
+
+  ## Example (errors)
+
+        iex> Xlsxir.multi_extract("./test/test_data/test.invalidfile", 0)
+        {:error, "Invalid file type (expected xlsx)."}
+
+        iex> Xlsxir.multi_extract("./test/test_data/test.xlsx", 100)
+        {:error, "Invalid worksheet index."}
   """
   def multi_extract(path, index \\ nil, timer \\ false, _excel \\ nil, options \\ [])
   def multi_extract(path, nil, timer, _excel, options) do

--- a/lib/xlsxir.ex
+++ b/lib/xlsxir.ex
@@ -31,6 +31,15 @@ defmodule Xlsxir do
   - `index` - index of worksheet from within the Excel workbook to be parsed (zero-based index)
   - `timer` - boolean flag that tracks extraction process time and returns it when set to `true`. Default value is `false`.
 
+  ## Options
+  - `:max_rows` - the number of rows to fetch from within the worksheet
+  - `:extract_to` - Specify how the `.xlsx` content (i.e. sharedStrings.xml,
+     style.xml and worksheets xml files) will be be extracted before being parsed.
+    `:memory` will extract files to memory, and `:file` to files in the file system
+  - `:extract_base_dir` - when extracting to file, files will be extracted
+     in a sub directory in the `:extract_base_dir` directory. Defaults to
+     `Application.get_env(:xlsxir, :extract_base_dir)` or "temp"
+
   ## Example
   Extract first worksheet in an example file named `test.xlsx` located in `./test/test_data`:
 
@@ -126,6 +135,14 @@ defmodule Xlsxir do
   - `index` - index of worksheet from within the Excel workbook to be parsed (zero-based index)
   - `rows` - the number of rows to fetch from within the specified worksheet
 
+  ## Options
+  - `:extract_to` - Specify how the `.xlsx` content (i.e. sharedStrings.xml,
+     style.xml and worksheets xml files) will be be extracted before being parsed.
+    `:memory` will extract files to memory, and `:file` to files in the file system
+  - `:extract_base_dir` - when extracting to file, files will be extracted
+     in a sub directory in the `:extract_base_dir` directory. Defaults to
+     `Application.get_env(:xlsxir, :extract_base_dir)` or "temp"
+
   ## Example
   Peek at the first 10 rows of the 9th worksheet in an example file named `test.xlsx` located in `./test/test_data`:
 
@@ -153,6 +170,15 @@ defmodule Xlsxir do
   - `path` - file path of a `.xlsx` file type in `string` format
   - `index` - index of worksheet from within the Excel workbook to be parsed (zero-based index)
   - `timer` - boolean flag that tracts extraction process time and returns it when set to `true`. Defalut value is `false`.
+
+  ## Options
+  - `:max_rows` - the number of rows to fetch from within the worksheets
+  - `:extract_to` - Specify how the `.xlsx` content (i.e. sharedStrings.xml,
+     style.xml and worksheets xml files) will be be extracted before being parsed.
+    `:memory` will extract files to memory, and `:file` to files in the file system
+  - `:extract_base_dir` - when extracting to file, files will be extracted
+     in a sub directory in the `:extract_base_dir` directory. Defaults to
+     `Application.get_env(:xlsxir, :extract_base_dir)` or "temp"
 
   ## Example
   Extract first worksheet in an example file named `test.xlsx` located in `./test/test_data`:

--- a/lib/xlsxir.ex
+++ b/lib/xlsxir.ex
@@ -1,5 +1,5 @@
 defmodule Xlsxir do
-  alias Xlsxir.{SaxParser, Unzip}
+  alias Xlsxir.{SaxParser, Unzip, XmlFile}
 
   defstruct [styles: nil, shared_strings: nil, worksheets: [], max_rows: nil, timer: nil]
 
@@ -68,8 +68,8 @@ defmodule Xlsxir do
     case Unzip.validate_path_and_index(path, index) do
       {:ok, file}      ->
         case extract_xml(file, index) do
-          {:ok, file_paths} ->
-            {excel, result} = do_extract(excel, file_paths, index)
+          {:ok, xml_files} ->
+            {excel, result} = do_extract(excel, xml_files, index)
             if excel.styles, do: :ets.delete(excel.styles)
             if excel.shared_strings, do: :ets.delete(excel.shared_strings)
             result
@@ -79,24 +79,24 @@ defmodule Xlsxir do
     end
   end
 
-  defp do_extract(%__MODULE__{timer: timer} = excel, file_paths, index) do
-    excel = Enum.reduce(file_paths, excel, fn {file, content}, acc ->
+  defp do_extract(%__MODULE__{timer: timer} = excel, xml_files, index) do
+    excel = Enum.reduce(xml_files, excel, fn xml_file, acc ->
       cond do
-        file == 'xl/sharedStrings.xml' && is_nil(excel.shared_strings) ->
-          {:ok, %Xlsxir.ParseString{tid: tid}, _} = SaxParser.parse(content, :string)
+        xml_file.name == "sharedStrings.xml" && is_nil(excel.shared_strings) ->
+          {:ok, %Xlsxir.ParseString{tid: tid}, _} = SaxParser.parse(xml_file, :string)
           %{acc | shared_strings: tid}
-        file == 'xl/styles.xml' && is_nil(excel.styles) ->
-          {:ok, %Xlsxir.ParseStyle{tid: tid}, _} = SaxParser.parse(content, :style)
+        xml_file.name == "styles.xml" && is_nil(excel.styles) ->
+          {:ok, %Xlsxir.ParseStyle{tid: tid}, _} = SaxParser.parse(xml_file, :style)
           %{acc | styles: tid}
         true -> acc
       end
     end)
 
-    {_, content} = Enum.find(file_paths, fn {path, _} ->
-      path == 'xl/worksheets/sheet#{index + 1}.xml'
+    worksheet_xml_file = Enum.find(xml_files, fn xml_file ->
+      xml_file.name == "sheet#{index + 1}.xml"
     end)
 
-    {:ok, %Xlsxir.ParseWorksheet{tid: tid}, _} = SaxParser.parse(content, :worksheet, excel)
+    {:ok, %Xlsxir.ParseWorksheet{tid: tid}, _} = SaxParser.parse(worksheet_xml_file, :worksheet, excel)
 
     if !is_nil(timer) do
       {excel, {:ok, tid, stop_timer(excel.timer)}}
@@ -119,9 +119,10 @@ defmodule Xlsxir do
   ## Example
   Extract first worksheet in an example file named `test.xlsx` located in `./test/test_data`:
 
-        iex> Xlsxir.stream_list("./test/test_data/test.xlsx", 1) |> Enum.take(2)
+        iex> Xlsxir.stream_list("./test/test_data/test.xlsx", 1) |> Enum.take(1)
+        [[1, 2]]
+        iex> Xlsxir.stream_list("./test/test_data/test.xlsx", 1) |> Enum.take(3)
         [[1, 2], [3, 4]]
-
   """
   def stream_list(path, index) do
     stream(path, index)
@@ -130,7 +131,7 @@ defmodule Xlsxir do
 
   defp stream(path, index) do
     Stream.resource(
-      fn -> prepare_stream(path, index) end,
+      fn -> initialize_stream(path, index) end,
       &stream_next_row/1,
       &clean_stream/1
     )
@@ -142,25 +143,28 @@ defmodule Xlsxir do
     |> Enum.map(fn [_ref, val] -> val end) # [1, nil, 2]
   end
 
-  defp prepare_stream(path, index) do
-    with  {:ok, file} <- Unzip.validate_path_and_index(path, index),
-          {:ok, file_paths} <- extract_xml(file, index),
-          excel <- extract_commons(file_paths, %__MODULE__{}),
-          {:ok, content} <- open_worksheet(file_paths, index) do
+  defp initialize_stream(xls_file_path, index) do
+    with  {:ok, xls_file_path} <- Unzip.validate_path_and_index(xls_file_path, index),
+          {:ok, xml_files} <- extract_xml(xls_file_path, index, :file),
+          excel <- parse_commons(xml_files, %__MODULE__{}),
+          {:ok, worksheet_xml_file} <- get_worksheet_xml_file(xml_files, index) do
 
-      xml_parser_pid = spawn(__MODULE__, :parse_loop, [content, excel])
-      {xml_parser_pid, excel}
+      sax_parser_pid = spawn(__MODULE__, :parse_worksheet_loop, [worksheet_xml_file, excel])
+      {sax_parser_pid, excel}
+    else
+      {:error, details} -> raise "Error during stream initialization: #{inspect details}"
+      _ -> raise "Error during stream initialization"
     end
   end
 
-  def parse_loop(content, excel) do
-    SaxParser.parse(content, :stream_worksheet, excel)
+  @doc false
+  def parse_worksheet_loop(worksheet_xml_file, excel) do
+    SaxParser.parse(worksheet_xml_file, :stream_worksheet, excel)
   end
 
-  defp stream_next_row(stream_state)
-  defp stream_next_row({xml_parser_pid, _excel} = stream_state) do
+  defp stream_next_row({sax_parser_pid, _excel} = stream_state) do
     # Ask next row to the xml parser process
-    send(xml_parser_pid, {:get_next_row, self()})
+    send(sax_parser_pid, {:get_next_row, self()})
 
     # And wait for a response, ie a next row or end of file
     receive do
@@ -171,39 +175,53 @@ defmodule Xlsxir do
     end
   end
 
-  defp clean_stream(stream_state)
-  defp clean_stream({xml_parser_pid, excel}) do
-    # Kill parser loop process
-    Process.exit(xml_parser_pid, :kill)
-
-    # Removes ETS tables after worksheet streaming ends
-    if excel.styles, do: :ets.delete(excel.styles)
-    if excel.shared_strings, do: :ets.delete(excel.shared_strings)
+  defp clean_stream({sax_parser_pid, excel}) do
+    # Kill parser loop process and remove common ETS tables
+    Process.exit(sax_parser_pid, :kill)
+    clean_commons(excel)
+    clean_temp_folder()
   end
 
-  defp extract_commons(file_paths, excel) do
-    file_paths
-    |> Enum.reduce(excel, &extract_common/2)
+  defp parse_commons(xml_files, excel) do
+    xml_files
+    |> Enum.reduce(excel, &parse_common/2)
   end
 
-  defp extract_common({'xl/sharedStrings.xml', content}, excel) do
-    {:ok, %Xlsxir.ParseString{tid: tid}, _} = SaxParser.parse(content, :string)
+  defp parse_common(%XmlFile{name: "sharedStrings.xml"} = xml_file, excel) do
+    {:ok, %Xlsxir.ParseString{tid: tid}, _} = SaxParser.parse(xml_file, :string)
     %{excel | shared_strings: tid}
   end
 
-  defp extract_common({'xl/styles.xml', content}, excel) do
-    {:ok, %Xlsxir.ParseStyle{tid: tid}, _} = SaxParser.parse(content, :style)
+  defp parse_common(%XmlFile{name: "styles.xml"} = xml_file, excel) do
+    {:ok, %Xlsxir.ParseStyle{tid: tid}, _} = SaxParser.parse(xml_file, :style)
     %{excel | styles: tid}
   end
 
   # ignore other files and worksheets
-  defp extract_common(_, excel), do: excel
+  defp parse_common(_, excel), do: excel
 
-  defp open_worksheet(file_paths, index) do
-    {_, content} = Enum.find(file_paths, fn {path, _} ->
-      path == 'xl/worksheets/sheet#{index + 1}.xml'
+  defp get_worksheet_xml_file(xml_files, index) do
+    xml_file = Enum.find(xml_files, fn %XmlFile{name: name} ->
+      name == "sheet#{index + 1}.xml"
     end)
-    {:ok, content}
+
+    case xml_file do
+      nil -> {:error, "Worksheet not found"}
+      xml_file -> {:ok, xml_file}
+    end
+  end
+
+  defp clean_commons(excel) do
+    # Removes ETS tables
+    if excel.styles, do: :ets.delete(excel.styles)
+    if excel.shared_strings, do: :ets.delete(excel.shared_strings)
+  end
+
+  # When xls file are extracted to temp folder
+  # TODO: temporary solution
+  defp clean_temp_folder do
+    File.rm_rf("./temp")
+    :ok
   end
 
 
@@ -230,8 +248,8 @@ defmodule Xlsxir do
     case Unzip.validate_path_and_index(path, index) do
       {:ok, file}      ->
         case extract_xml(file, index) do
-          {:ok, file_paths} ->
-            {excel, result} = do_extract(excel, file_paths, index)
+          {:ok, xml_files} ->
+            {excel, result} = do_extract(excel, xml_files, index)
             :ets.delete(excel.styles)
             :ets.delete(excel.shared_strings)
             result
@@ -241,9 +259,9 @@ defmodule Xlsxir do
     end
   end
 
-  defp extract_xml(file, index) do
+  defp extract_xml(file, index, to \\ :memory) do
     Unzip.xml_file_list(index)
-    |> Unzip.extract_xml_to_memory(file)
+    |> Unzip.extract_xml(file, to)
   end
 
   @doc """
@@ -318,8 +336,8 @@ defmodule Xlsxir do
         case Unzip.validate_path_and_index(path, index) do
           {:ok, file}      -> extract_xml(file, index)
                               |> case do
-                                {:ok, file_paths} ->
-                                  {excel, result} = do_extract(excel, file_paths, index)
+                                {:ok, xml_files} ->
+                                  {excel, result} = do_extract(excel, xml_files, index)
                                   if initial_parse do
                                     :ets.delete(excel.styles)
                                     :ets.delete(excel.shared_strings)

--- a/lib/xlsxir.ex
+++ b/lib/xlsxir.ex
@@ -119,6 +119,8 @@ defmodule Xlsxir do
   ## Example
   Extract first worksheet in an example file named `test.xlsx` located in `./test/test_data`:
 
+        iex> with %Stream{} <- Xlsxir.stream_list("./test/test_data/test.xlsx", 1), do: true
+        true
         iex> Xlsxir.stream_list("./test/test_data/test.xlsx", 1) |> Enum.take(1)
         [[1, 2]]
         iex> Xlsxir.stream_list("./test/test_data/test.xlsx", 1) |> Enum.take(3)

--- a/lib/xlsxir/parse_worksheet.ex
+++ b/lib/xlsxir/parse_worksheet.ex
@@ -20,15 +20,15 @@ defmodule Xlsxir.ParseWorksheet do
   ## Example
   Each entry in the list created consists of a list containing a cell reference string and the associated value (i.e. `[["A1", "string one"], ...]`).
   """
-  def sax_event_handler(:startDocument, _state, %Xlsxir{max_rows: max_rows}) do
+  def sax_event_handler(:startDocument, _state, %{max_rows: max_rows}) do
     %__MODULE__{tid: GenServer.call(Xlsxir.StateManager, :new_table), max_rows: max_rows}
   end
 
-  def sax_event_handler({:startElement,_,'row',_,_}, %{tid: tid, max_rows: max_rows}, _excel) do
+  def sax_event_handler({:startElement,_,'row',_,_}, %__MODULE__{tid: tid, max_rows: max_rows}, _excel) do
     %__MODULE__{tid: tid, max_rows: max_rows}
   end
 
-  def sax_event_handler({:startElement,_,'c',_,xml_attr}, state, %Xlsxir{styles: styles_tid}) do
+  def sax_event_handler({:startElement,_,'c',_,xml_attr}, state, %{styles: styles_tid}) do
     a = Enum.map(xml_attr, fn(attr) ->
           case attr do
             {:attribute,'r',_,_,ref}   -> {:r, ref  }
@@ -52,12 +52,12 @@ defmodule Xlsxir.ParseWorksheet do
     if state == nil, do: nil, else: %{state | value: value}
   end
 
-  def sax_event_handler({:endElement,_,'c',_}, %{row: row} = state, %Xlsxir{} = excel) do
+  def sax_event_handler({:endElement,_,'c',_}, %__MODULE__{row: row} = state, excel) do
     cell_value = format_cell_value(excel, [state.data_type, state.num_style, state.value])
     %{state | row: Enum.into(row, [[to_string(state.cell_ref), cell_value]]), cell_ref: "", data_type: "", num_style: "", value: ""}
   end
 
-  def sax_event_handler({:endElement,_,'row',_}, %{tid: tid, max_rows: max_rows} = state, _excel) do
+  def sax_event_handler({:endElement,_,'row',_}, %__MODULE__{tid: tid, max_rows: max_rows} = state, _excel) do
     unless Enum.empty?(state.row) do
       [[row]] = ~r/\d+/ |> Regex.scan(state.row |> List.first |> List.first)
       row     = row |> String.to_integer
@@ -70,7 +70,7 @@ defmodule Xlsxir.ParseWorksheet do
 
   def sax_event_handler(_, state, _), do: state
 
-  defp format_cell_value(%Xlsxir{shared_strings: strings_tid}, list) do
+  defp format_cell_value(%{shared_strings: strings_tid}, list) do
     case list do
       [          _,   _, nil] -> nil                                                                 # Cell with no value attribute
       [          _,   _,  ""] -> nil                                                                 # Empty cell with assigned attribute

--- a/lib/xlsxir/parse_worksheet.ex
+++ b/lib/xlsxir/parse_worksheet.ex
@@ -24,7 +24,7 @@ defmodule Xlsxir.ParseWorksheet do
     %__MODULE__{tid: GenServer.call(Xlsxir.StateManager, :new_table), max_rows: max_rows}
   end
 
-  def sax_event_handler({:startElement,_,'row',_,_}, %__MODULE__{tid: tid, max_rows: max_rows}, _excel) do
+  def sax_event_handler({:startElement,_,'row',_,_}, %{tid: tid, max_rows: max_rows}, _excel) do
     %__MODULE__{tid: tid, max_rows: max_rows}
   end
 
@@ -52,12 +52,12 @@ defmodule Xlsxir.ParseWorksheet do
     if state == nil, do: nil, else: %{state | value: value}
   end
 
-  def sax_event_handler({:endElement,_,'c',_}, %__MODULE__{row: row} = state, %Xlsxir{} = excel) do
+  def sax_event_handler({:endElement,_,'c',_}, %{row: row} = state, %Xlsxir{} = excel) do
     cell_value = format_cell_value(excel, [state.data_type, state.num_style, state.value])
     %{state | row: Enum.into(row, [[to_string(state.cell_ref), cell_value]]), cell_ref: "", data_type: "", num_style: "", value: ""}
   end
 
-  def sax_event_handler({:endElement,_,'row',_}, %__MODULE__{tid: tid, max_rows: max_rows} = state, _excel) do
+  def sax_event_handler({:endElement,_,'row',_}, %{tid: tid, max_rows: max_rows} = state, _excel) do
     unless Enum.empty?(state.row) do
       [[row]] = ~r/\d+/ |> Regex.scan(state.row |> List.first |> List.first)
       row     = row |> String.to_integer

--- a/lib/xlsxir/sax_parser.ex
+++ b/lib/xlsxir/sax_parser.ex
@@ -4,7 +4,7 @@ defmodule Xlsxir.SaxParser do
   parsing algorithm for parsing large XML files in chunks, preventing the need to load the entire DOM into memory. Current chunk size is set to 10,000.
   """
 
-  alias Xlsxir.{ParseString, ParseStyle, ParseWorksheet, SaxError}
+  alias Xlsxir.{ParseString, ParseStyle, ParseWorksheet, StreamWorksheet, SaxError}
   require Logger
 
   @chunk 10000
@@ -50,6 +50,7 @@ defmodule Xlsxir.SaxParser do
         nil,
         case type do
           :worksheet -> &(ParseWorksheet.sax_event_handler(&1, &2, excel))
+          :stream_worksheet -> &(StreamWorksheet.sax_event_handler(&1, &2, excel))
           :style     -> &(ParseStyle.sax_event_handler(&1, &2))
           :string    -> &(ParseString.sax_event_handler(&1, &2))
           _          -> raise "Invalid file type for sax_event_handler/2"
@@ -68,5 +69,4 @@ defmodule Xlsxir.SaxParser do
       :eof        -> {tail, {pid, offset, chunk}}
     end
   end
-
 end

--- a/lib/xlsxir/sax_parser.ex
+++ b/lib/xlsxir/sax_parser.ex
@@ -35,7 +35,7 @@ defmodule Xlsxir.SaxParser do
           iex> {:ok, %Xlsxir.ParseString{tid: tid2}, _} = Xlsxir.SaxParser.parse(%Xlsxir.XmlFile{content: File.read!("./test/test_data/test/xl/sharedStrings.xml")}, :string)
           iex> :ets.lookup(tid2, 0)
           [{0, "string one"}]
-          iex> {:ok, %Xlsxir.ParseWorksheet{tid: tid3}, _} = Xlsxir.SaxParser.parse(%Xlsxir.XmlFile{content: File.read!("./test/test_data/test/xl/worksheets/sheet1.xml")}, :worksheet, %Xlsxir{shared_strings: tid2, styles: tid1})
+          iex> {:ok, %Xlsxir.ParseWorksheet{tid: tid3}, _} = Xlsxir.SaxParser.parse(%Xlsxir.XmlFile{content: File.read!("./test/test_data/test/xl/worksheets/sheet1.xml")}, :worksheet, %Xlsxir.XlsxFile{shared_strings: tid2, styles: tid1})
           iex> :ets.lookup(tid3, 1)
           [{1, [["A1", "string one"], ["B1", "string two"], ["C1", 10], ["D1", 20], ["E1", {2016, 1, 1}]]}]
   """

--- a/lib/xlsxir/sax_parser.ex
+++ b/lib/xlsxir/sax_parser.ex
@@ -4,13 +4,13 @@ defmodule Xlsxir.SaxParser do
   parsing algorithm for parsing large XML files in chunks, preventing the need to load the entire DOM into memory. Current chunk size is set to 10,000.
   """
 
-  alias Xlsxir.{ParseString, ParseStyle, ParseWorksheet, StreamWorksheet, SaxError}
+  alias Xlsxir.{ParseString, ParseStyle, ParseWorksheet, StreamWorksheet, SaxError, XmlFile}
   require Logger
 
   @chunk 10000
 
   @doc """
-  Parses `xl/worksheets/sheet\#{n}.xml` at index `n`, `xl/styles.xml` and `xl/sharedStrings.xml` using SAX parsing. An Erlang Term Storage (ETS) process is started to hold the state of data
+  Parses `XmlFile` (`xl/worksheets/sheet\#{n}.xml` at index `n`, `xl/styles.xml` or `xl/sharedStrings.xml`) using SAX parsing. An Erlang Term Storage (ETS) process is started to hold the state of data
   parsed. The style and sharedstring XML files (if they exist) must be parsed first in order for the worksheet parser to sucessfully complete.
 
   ## Parameters
@@ -29,18 +29,18 @@ defmodule Xlsxir.SaxParser do
     The `.xlsx` file contents have been extracted to `./test/test_data/test`. For purposes of this example, we utilize the `get_at/1` function of each ETS process module to pull a sample of the parsed
     data. Keep in mind that the worksheet data is stored in the ETS process as a list of row lists, so the `Xlsxir..get_row/2` function will return a full row of values.
 
-          iex> {:ok, %Xlsxir.ParseStyle{tid: tid1}, _} = Xlsxir.SaxParser.parse(File.read!("./test/test_data/test/xl/styles.xml"), :style)
+          iex> {:ok, %Xlsxir.ParseStyle{tid: tid1}, _} = Xlsxir.SaxParser.parse(%Xlsxir.XmlFile{content: File.read!("./test/test_data/test/xl/styles.xml")}, :style)
           iex> :ets.lookup(tid1, 0)
           [{0, nil}]
-          iex> {:ok, %Xlsxir.ParseString{tid: tid2}, _} = Xlsxir.SaxParser.parse(File.read!("./test/test_data/test/xl/sharedStrings.xml"), :string)
+          iex> {:ok, %Xlsxir.ParseString{tid: tid2}, _} = Xlsxir.SaxParser.parse(%Xlsxir.XmlFile{content: File.read!("./test/test_data/test/xl/sharedStrings.xml")}, :string)
           iex> :ets.lookup(tid2, 0)
           [{0, "string one"}]
-          iex> {:ok, %Xlsxir.ParseWorksheet{tid: tid3}, _} = Xlsxir.SaxParser.parse(File.read!("./test/test_data/test/xl/worksheets/sheet1.xml"), :worksheet, %Xlsxir{shared_strings: tid2, styles: tid1})
+          iex> {:ok, %Xlsxir.ParseWorksheet{tid: tid3}, _} = Xlsxir.SaxParser.parse(%Xlsxir.XmlFile{content: File.read!("./test/test_data/test/xl/worksheets/sheet1.xml")}, :worksheet, %Xlsxir{shared_strings: tid2, styles: tid1})
           iex> :ets.lookup(tid3, 1)
           [{1, [["A1", "string one"], ["B1", "string two"], ["C1", 10], ["D1", 20], ["E1", {2016, 1, 1}]]}]
   """
-  def parse(content, type, excel \\ nil) do
-    {:ok, file_pid} = File.open(content, [:binary, :ram])
+  def parse(%XmlFile{} = xml_file, type, excel \\ nil) do
+    {:ok, file_pid} = XmlFile.open(xml_file)
 
     index   = 0
     c_state = {file_pid, index, @chunk}
@@ -49,17 +49,17 @@ defmodule Xlsxir.SaxParser do
       :erlsom.parse_sax("",
         nil,
         case type do
-          :worksheet -> &(ParseWorksheet.sax_event_handler(&1, &2, excel))
+          :worksheet        -> &(ParseWorksheet.sax_event_handler(&1, &2, excel))
           :stream_worksheet -> &(StreamWorksheet.sax_event_handler(&1, &2, excel))
-          :style     -> &(ParseStyle.sax_event_handler(&1, &2))
-          :string    -> &(ParseString.sax_event_handler(&1, &2))
-          _          -> raise "Invalid file type for sax_event_handler/2"
+          :style            -> &(ParseStyle.sax_event_handler(&1, &2))
+          :string           -> &(ParseString.sax_event_handler(&1, &2))
+          _                 -> raise "Invalid file type for sax_event_handler/2"
         end,
         [{:continuation_function, &continue_file/2, c_state}])
     rescue e in SaxError ->
       {:ok, e.state, []}
-      after
-        File.close(file_pid)
+    after
+      File.close(file_pid)
     end
   end
 

--- a/lib/xlsxir/stream_worksheet.ex
+++ b/lib/xlsxir/stream_worksheet.ex
@@ -30,7 +30,7 @@ defmodule Xlsxir.StreamWorksheet do
   """
   def sax_event_handler(sax_pattern, state, excel)
 
-  def sax_event_handler(:startDocument, _state, %Xlsxir{}) do
+  def sax_event_handler(:startDocument, _state, %Xlsxir.XlsxFile{}) do
     %ParseWorksheet{}
   end
 

--- a/lib/xlsxir/stream_worksheet.ex
+++ b/lib/xlsxir/stream_worksheet.ex
@@ -1,0 +1,61 @@
+defmodule Xlsxir.StreamWorksheet do
+  @moduledoc """
+  Holds the special SAX event instructions for parsing and streaming
+  worksheet data rows via `Xlsxir.SaxParser.parse/2`
+
+  Delegates other SAX event instructions to `Xlsxir.ParseWorksheet`
+  """
+
+  alias Xlsxir.ParseWorksheet
+
+  @doc """
+  Sax event utilized by `Xlsxir.SaxParser.parse/2`.
+
+  Takes a pattern and the current state of a struct and recursivly parses the
+  worksheet XML file.
+
+  Blocks the process when a row is fully parsed, with cell references
+  and their assocated values, then wait for a message from a parent process
+  to callback and send the row data.
+
+  ## Parameters
+
+  - `sax_pattern` - the XML pattern of the event to match upon
+  - `state` - the state of the `%Xlsxir.StreamWorksheet{}` struct which temporarily holds applicable data of the current row being parsed
+
+  ## Example
+
+  Each row data sent consists of a list containing a cell reference string
+  and the associated value (i.e. `[["A1", "string one"], ...]`).
+  """
+  def sax_event_handler(sax_pattern, state, excel)
+
+  def sax_event_handler(:startDocument, _state, %Xlsxir{}) do
+    %ParseWorksheet{}
+  end
+
+  def sax_event_handler({:endElement,_,'row',_}, state, _excel) do
+    unless Enum.empty?(state.row) do
+      value = state.row |> Enum.reverse
+
+      # Wait for parent process to ask for the next row
+      receive do
+        {:get_next_row, from} -> send(from, {:next_row, value})
+      end
+    end
+    state
+  end
+
+  def sax_event_handler(:endDocument, _state, _excel) do
+    # If the end of the document is reached, and if the
+    # parent process ask for a next row, sends the `end` message
+    receive do
+      {:get_next_row, from} -> send(from, {:end})
+    end
+  end
+
+  # Delegates other SAX events to Xlsxir.ParseWorksheet
+  def sax_event_handler(sax_event, state, excel) do
+    ParseWorksheet.sax_event_handler(sax_event, state, excel)
+  end
+end

--- a/lib/xlsxir/unzip.ex
+++ b/lib/xlsxir/unzip.ex
@@ -3,8 +3,8 @@ defmodule Xlsxir.Unzip do
   alias Xlsxir.XmlFile
 
   @moduledoc """
-  Provides validation of accepted file types for file path, extracts required `.xlsx` contents to memory
-  or `./temp` (and ultimately deletes the `./temp` directory and its contents).
+  Provides validation of accepted file types for file path,
+  extracts required `.xlsx` contents to memory or files
   """
   @filetype_error "Invalid file type (expected xlsx)."
   @xml_not_found_error "Invalid File. Required XML files not found."
@@ -111,27 +111,6 @@ defmodule Xlsxir.Unzip do
   end
 
   @doc """
-  List of files contained in the requested `.xlsx` file to be extracted.
-
-  ## Parameters
-
-  - `index` - index of the `.xlsx` worksheet to be parsed
-
-  ## Example
-
-         iex> Xlsxir.Unzip.xml_file_list(0)
-         ['xl/styles.xml', 'xl/sharedStrings.xml', 'xl/worksheets/sheet1.xml']
-  """
-  def xml_file_list(index) do
-    [
-     'xl/styles.xml',
-     'xl/sharedStrings.xml',
-     'xl/worksheets/sheet#{index + 1}.xml'
-    ]
-  end
-
-
-  @doc """
   Extracts requested list of files from a `.zip` file to memory or file system
   and returns a list of the extracted file paths.
 
@@ -139,7 +118,7 @@ defmodule Xlsxir.Unzip do
 
   - `file_list` - list containing file paths to be extracted in `char_list` format
   - `path` - file path of a `.xlsx` file type in `string` format
-  - `to` - `:memory` or `:file` option
+  - `to` - `:memory` or `{:file, "destination/path"}` option
 
   ## Example
   An example file named `test.zip` located in './test_data/test' containing a single file named `test.txt`:
@@ -148,8 +127,10 @@ defmodule Xlsxir.Unzip do
       iex> file_list = ['test.txt']
       iex> Xlsxir.Unzip.extract_xml(file_list, path, :memory)
       {:ok, [%Xlsxir.XmlFile{content: "test_successful", name: "test.txt", path: nil}]}
-      iex> Xlsxir.Unzip.extract_xml(file_list, path, :file)
+      iex> Xlsxir.Unzip.extract_xml(file_list, path, {:file, "temp/"})
       {:ok, [%Xlsxir.XmlFile{content: nil, name: "test.txt", path: "temp/test.txt"}]}
+      iex> with {:ok, _} <- File.rm_rf("temp"), do: :ok
+      :ok
   """
   def extract_xml(file_list, path, to) do
     path
@@ -163,7 +144,7 @@ defmodule Xlsxir.Unzip do
   end
 
   defp extract_from_zip(path, file_list, :memory), do: :zip.extract(path, [{:file_list, file_list}, :memory])
-  defp extract_from_zip(path, file_list, :file), do: :zip.extract(path, [{:file_list, file_list}, {:cwd, 'temp/'}])
+  defp extract_from_zip(path, file_list, {:file, dest_path}), do: :zip.extract(path, [{:file_list, file_list}, {:cwd, dest_path}])
 
   defp build_xml_files(files_list) do
     files_list

--- a/lib/xlsxir/unzip.ex
+++ b/lib/xlsxir/unzip.ex
@@ -30,6 +30,10 @@ defmodule Xlsxir.Unzip do
          iex> path = "./test/test_data/test.xlsx"
          iex> Xlsxir.Unzip.validate_path_and_index(path, 100)
          {:error, "Invalid worksheet index."}
+
+         iex> path = "./test/test_data/test.invalidfile"
+         iex> Xlsxir.Unzip.validate_path_and_index(path, 0)
+         {:error, "Invalid file type (expected xlsx)."}
   """
   def validate_path_and_index(path, index) do
     path = String.to_char_list(path)
@@ -56,6 +60,10 @@ defmodule Xlsxir.Unzip do
          iex> path = "./test/test_data/test.zip"
          iex> Xlsxir.Unzip.validate_path_all_indexes(path)
          {:ok, []}
+
+         iex> path = "./test/test_data/test.invalidfile"
+         iex> Xlsxir.Unzip.validate_path_all_indexes(path)
+         {:error, "Invalid file type (expected xlsx)."}
   """
 
   def validate_path_all_indexes(path) do

--- a/lib/xlsxir/unzip.ex
+++ b/lib/xlsxir/unzip.ex
@@ -1,7 +1,10 @@
 defmodule Xlsxir.Unzip do
 
+  alias Xlsxir.XmlFile
+
   @moduledoc """
-  Provides validation of accepted file types for file path, extracts required `.xlsx` contents to memory.
+  Provides validation of accepted file types for file path, extracts required `.xlsx` contents to memory
+  or `./temp` (and ultimately deletes the `./temp` directory and its contents).
   """
   @filetype_error "Invalid file type (expected xlsx)."
   @xml_not_found_error "Invalid File. Required XML files not found."
@@ -127,30 +130,53 @@ defmodule Xlsxir.Unzip do
     ]
   end
 
+
   @doc """
-  Extracts requested list of files from a `.zip` file to memory and returns a list of the extracted file paths.
+  Extracts requested list of files from a `.zip` file to memory or file system
+  and returns a list of the extracted file paths.
 
   ## Parameters
 
   - `file_list` - list containing file paths to be extracted in `char_list` format
   - `path` - file path of a `.xlsx` file type in `string` format
+  - `to` - `:memory` or `:file` option
 
   ## Example
   An example file named `test.zip` located in './test_data/test' containing a single file named `test.txt`:
 
       iex> path = "./test/test_data/test.zip"
       iex> file_list = ['test.txt']
-      iex> Xlsxir.Unzip.extract_xml_to_memory(file_list, path)
-      {:ok, [{'test.txt', "test_successful"}]}
+      iex> Xlsxir.Unzip.extract_xml(file_list, path, :memory)
+      {:ok, [%Xlsxir.XmlFile{content: "test_successful", name: "test.txt", path: nil}]}
+      iex> Xlsxir.Unzip.extract_xml(file_list, path, :file)
+      {:ok, [%Xlsxir.XmlFile{content: nil, name: "test.txt", path: "temp/test.txt"}]}
   """
-  def extract_xml_to_memory(file_list, path) do
+  def extract_xml(file_list, path, to) do
     path
     |> to_char_list
-    |> :zip.extract([{:file_list, file_list}, :memory])
+    |> extract_from_zip(file_list, to)
     |> case do
         {:error, reason}  -> {:error, reason}
         {:ok, []}         -> {:error, @xml_not_found_error}
-        {:ok, files_list} -> {:ok, files_list}
+        {:ok, files_list} -> {:ok, build_xml_files(files_list)}
        end
+  end
+
+  defp extract_from_zip(path, file_list, :memory), do: :zip.extract(path, [{:file_list, file_list}, :memory])
+  defp extract_from_zip(path, file_list, :file), do: :zip.extract(path, [{:file_list, file_list}, {:cwd, 'temp/'}])
+
+  defp build_xml_files(files_list) do
+    files_list
+    |> Enum.map(&build_xml_file/1)
+  end
+
+  # When extracting to memory
+  defp build_xml_file({name, content}) do
+    %XmlFile{name: Path.basename(name), content: content}
+  end
+
+  # When extracting to temp file
+  defp build_xml_file(file_path) do
+    %XmlFile{name:  Path.basename(file_path), path: to_string(file_path)}
   end
 end

--- a/lib/xlsxir/xlsx_file.ex
+++ b/lib/xlsxir/xlsx_file.ex
@@ -1,0 +1,231 @@
+defmodule Xlsxir.XlsxFile do
+  @moduledoc """
+  Struct and helper functions to extract and process `.xslx` files
+
+  ## Example
+
+    iex> xlsx_file = Xlsxir.XlsxFile.initialize("./test/test_data/test.xlsx")
+    iex> {:ok, _tid} = Xlsxir.XlsxFile.parse_to_ets(xlsx_file, 0)
+    iex> Xlsxir.XlsxFile.clean(xlsx_file)
+    :ok
+  """
+
+  alias Xlsxir.Unzip
+  alias Xlsxir.XmlFile
+  alias Xlsxir.SaxParser
+
+  defstruct worksheet_xml_files: [], # list of worksheet %XmlFile{}
+            shared_strings_xml_file: nil, # shared strings %XmlFile{}
+            styles_xml_file: nil, # styles %XmlFile{}
+            styles: nil, # ets table id
+            shared_strings: nil, # ets table id
+
+            max_rows: nil, # maximum rows to process during extraction to ETS
+            extract_to: nil,
+            extract_dir: nil,
+            options: []
+
+  @default_options  extract_to: :memory,
+                    extract_base_dir: nil
+
+
+
+  @doc """
+  Extract and prepare `.xlsx` file content.
+
+  ## Parameters
+  - `path` - file path of a `.xlsx` file type in `string` format
+
+  ## Options
+  - `:max_rows` - the number of rows to fetch from within the worksheet
+  - `:extract_to` - Specify where how the `.xlsx` content (i.e. sharedStrings.xml,
+     style.xml and worksheets xml files) will be be extracted before being parsed.
+    `:memory` will extract files to memory, and `:file` to files in the file system
+  - `:extract_base_dir` - when extracting to file, files will be extracted
+     in a sub directory in the `:extract_base_dir` directory. Defaults to
+     `Application.get_env(:xlsxir, :extract_base_dir)` or "temp"
+  """
+  def initialize(xlsx_filepath, options \\ []) do
+    options = Keyword.merge(@default_options, options)
+    max_rows = Keyword.get(options, :max_rows)
+    extract_to = Keyword.get(options, :extract_to)
+    extract_dir = build_extract_dir(options)
+
+    %__MODULE__{max_rows: max_rows, extract_to: extract_to, extract_dir: extract_dir}
+    |> extract_all_xml_files(xlsx_filepath) # Could be optimized to only unzip commons and requested worksheet
+    |> parse_shared_strings_to_ets
+    |> parse_styles_to_ets
+  end
+
+  @doc """
+  Parse a worksheet of the XlsxFile and store its content in a ETS table.
+  returns `{:ok, table_id}` when `timer` is `false`
+  and `{:ok, table_id, time}` when `timer` is `true`
+  """
+  def parse_to_ets(xlsx_file, worksheet_index_or_file, timer \\ false)
+  def parse_to_ets(%__MODULE__{} = xlsx_file, worksheet_index, timer) when is_integer(worksheet_index) do
+    worksheet_xml_file = get_worksheet(xlsx_file, worksheet_index)
+    parse_to_ets(xlsx_file, worksheet_xml_file, timer)
+  end
+
+  def parse_to_ets(%__MODULE__{} = xlsx_file, %XmlFile{} = worksheet_xml_file, true) do
+    start_timestamp = :erlang.timestamp
+    {:ok, tid} = parse_to_ets(xlsx_file, worksheet_xml_file, false)
+    end_timestamp = :erlang.timestamp
+    {:ok, tid, duration(start_timestamp, end_timestamp)}
+  end
+
+  def parse_to_ets(%__MODULE__{} = xlsx_file, %XmlFile{} = worksheet_xml_file, false) do
+    {:ok, %Xlsxir.ParseWorksheet{tid: tid}, _} = SaxParser.parse(worksheet_xml_file, :worksheet, xlsx_file)
+    {:ok, tid}
+  end
+
+  @doc """
+  Parse all worksheets of the XlsxFile and store their content in ETS tables.
+  returns `[{:ok, worksheet_1_table_id}, ..., {:ok, worksheet_n_table_id}]` when `timer` is `false`
+  and `[{:ok, worksheet_1_table_id, time1}, ..., {:ok, worksheet_n_table_id, timen}]` when `timer` is `true`
+  """
+  def parse_all_to_ets(%__MODULE__{} = xlsx_file, timer \\ false) do
+    xlsx_file.worksheet_xml_files
+    |> Enum.sort(&(&1.name <= &2.name)) # Sort worksheets by name (i.e. index)
+    |> Enum.map(&parse_to_ets(xlsx_file, &1, timer))
+  end
+
+  @doc """
+  Clean temp ETS tables and extraction folder
+  """
+  def clean(%__MODULE__{} = xlsx_file) do
+    # delete ETS tables
+    if xlsx_file.shared_strings, do: :ets.delete(xlsx_file.shared_strings)
+    if xlsx_file.styles, do: :ets.delete(xlsx_file.styles)
+
+    # Delete extract folder
+    if xlsx_file.extract_to == :file do
+      File.rm_rf!(xlsx_file.extract_dir)
+    end
+
+    :ok
+  end
+
+  @doc """
+  Parse a worksheet of the XlsxFile as a stream
+  """
+  def stream(%__MODULE__{} = xlsx_file, worksheet_index) do
+    Stream.resource(
+      fn -> initialize_stream(xlsx_file, worksheet_index) end,
+      &stream_next_row/1,
+      &clean_stream/1
+    )
+  end
+
+  ###############################################
+
+  defp build_extract_dir(options) do
+    case options[:extract_to] do
+      :file ->
+        extract_base_dir = build_extract_base_dir(options)
+        Path.join(extract_base_dir, Base.url_encode64(:crypto.strong_rand_bytes(10)))
+      _ ->
+        nil
+    end
+  end
+
+  defp build_extract_base_dir(options) do
+    Keyword.get(options, :extract_base_dir)
+    || Application.get_env(:xlsxir, :extract_base_dir)
+    || "temp"
+  end
+
+  defp initialize_stream(%__MODULE__{} = xlsx_file, worksheet_index) do
+    sax_parser_pid = spawn(__MODULE__, :parse_worksheet_loop, [get_worksheet(xlsx_file, worksheet_index), xlsx_file])
+    {sax_parser_pid, xlsx_file}
+  end
+
+  @doc false
+  def parse_worksheet_loop(worksheet_xml_file, xlsx_file) do
+    SaxParser.parse(worksheet_xml_file, :stream_worksheet, xlsx_file)
+  end
+
+  defp stream_next_row({sax_parser_pid, _xlsx_file} = stream_state) do
+    # Ask next row to the xml parser process
+    send(sax_parser_pid, {:get_next_row, self()})
+
+    # And wait for a response, ie a next row or end of file
+    receive do
+      {:next_row, row} ->
+        {[row], stream_state}
+      {:end} ->
+        {:halt, stream_state}
+    end
+  end
+
+  defp clean_stream({sax_parser_pid, xlsx_file}) do
+    # Kill parser loop process and remove common ETS tables
+    Process.exit(sax_parser_pid, :kill)
+    clean(xlsx_file)
+  end
+
+  defp extract_all_xml_files(%__MODULE__{} = xlsx_file, xlsx_filepath) do
+    {:ok, worksheet_indexes} = Unzip.validate_path_all_indexes(xlsx_filepath)
+    xml_paths_list = zip_paths_list(worksheet_indexes)
+    {:ok, xml_files} = Unzip.extract_xml(xml_paths_list, xlsx_filepath, unzip_options(xlsx_file))
+
+    %{
+      xlsx_file |
+        worksheet_xml_files: xml_files |> Enum.filter(fn %XmlFile{name: name} -> String.starts_with?(name, "sheet") end),
+        shared_strings_xml_file: xml_files |> Enum.find(fn %XmlFile{name: name} -> name == "sharedStrings.xml" end),
+        styles_xml_file: xml_files |> Enum.find(fn %XmlFile{name: name} -> name == "styles.xml" end)
+    }
+  end
+
+  defp unzip_options(xlsx_file) do
+    case xlsx_file.extract_to do
+      :file   -> {:file, xlsx_file.extract_dir}
+      :memory -> :memory
+    end
+  end
+
+  defp zip_paths_list(worksheet_indexes) do
+    worksheet_indexes
+    |> Enum.map(fn(worksheet_index) -> 'xl/worksheets/sheet#{worksheet_index + 1}.xml' end)
+    |> Enum.concat(['xl/styles.xml', 'xl/sharedStrings.xml'])
+  end
+
+  defp parse_styles_to_ets(%__MODULE__{} = xlsx_file) do
+    {:ok, %Xlsxir.ParseStyle{tid: tid}, _} = SaxParser.parse(xlsx_file.styles_xml_file, :style)
+    %{xlsx_file | styles: tid}
+  end
+
+  defp parse_shared_strings_to_ets(%__MODULE__{} = xlsx_file) do
+    {:ok, %Xlsxir.ParseString{tid: tid}, _} = SaxParser.parse(xlsx_file.shared_strings_xml_file, :string)
+    %{xlsx_file | shared_strings: tid}
+  end
+
+  defp get_worksheet(%__MODULE__{} = xlsx_file, index) do
+    Enum.find(xlsx_file.worksheet_xml_files, fn xml_file ->
+      xml_file.name == "sheet#{index + 1}.xml"
+    end)
+  end
+
+  defp duration(start_timestamp, end_timestamp) do
+    {_, s, ms} = end_timestamp
+    {_, start_s, start_ms} = start_timestamp
+
+    seconds      = s  |> Kernel.-(start_s)
+    microseconds = ms |> Kernel.+(start_ms)
+
+    [add_s, micro] = if microseconds > 1_000_000 do
+                       [1, microseconds - 1_000_000]
+                     else
+                       [0, microseconds]
+                     end
+
+    [h, m, s] = [
+                  seconds / 3600 |> Float.floor |> round,
+                  rem(seconds, 3600) / 60 |> Float.floor |> round,
+                  rem(seconds, 60)
+                ]
+
+    [h, m, s + add_s, micro]
+  end
+end

--- a/lib/xlsxir/xlsx_file.ex
+++ b/lib/xlsxir/xlsx_file.ex
@@ -38,7 +38,7 @@ defmodule Xlsxir.XlsxFile do
 
   ## Options
   - `:max_rows` - the number of rows to fetch from within the worksheet
-  - `:extract_to` - Specify where how the `.xlsx` content (i.e. sharedStrings.xml,
+  - `:extract_to` - Specify how the `.xlsx` content (i.e. sharedStrings.xml,
      style.xml and worksheets xml files) will be be extracted before being parsed.
     `:memory` will extract files to memory, and `:file` to files in the file system
   - `:extract_base_dir` - when extracting to file, files will be extracted

--- a/lib/xlsxir/xml_file.ex
+++ b/lib/xlsxir/xml_file.ex
@@ -1,0 +1,22 @@
+defmodule Xlsxir.XmlFile do
+  @moduledoc """
+  Struct that represents an XML file extracted from an `xlsx` file,
+  either in memory (in the `content` field) or on the filesystem
+  (located in the `path` field)
+  """
+
+  defstruct [name: nil, path: nil, content: nil]
+
+  @doc """
+  Open an XmlFile
+
+  ## Parameters
+  - `xml_file` - xml file to open
+  """
+  def open(%__MODULE__{} = xml_file) do
+    case Map.get(xml_file, :content, nil) do
+      nil -> File.open(xml_file.path, [:binary])
+      content -> File.open(content, [:binary, :ram])
+    end
+  end
+end

--- a/test/doc_test.exs
+++ b/test/doc_test.exs
@@ -4,4 +4,5 @@ defmodule DocTest do
   doctest Xlsxir.Unzip
   doctest Xlsxir.ConvertDate
   doctest Xlsxir.SaxParser
+  doctest Xlsxir.XlsxFile
 end

--- a/test/sax_parser_test.exs
+++ b/test/sax_parser_test.exs
@@ -2,9 +2,11 @@ defmodule SaxParserTest do
   use ExUnit.Case
 
   alias Xlsxir.SaxParser
+  alias Xlsxir.XmlFile
 
   test "reads complex shared strings correctly" do
-    {:ok, %{tid: tid}, _} = SaxParser.parse(File.read!("./test/test_data/complexStrings.xml"), :string)
+    xml_file = %XmlFile{content: File.read!("./test/test_data/complexStrings.xml")}
+    {:ok, %{tid: tid}, _} = SaxParser.parse(xml_file, :string)
 
     assert find_string(tid, 0) == "FOO: BAR"
     assert find_string(tid, 1) == "BAZ"

--- a/test/test_data/test.invalidfile
+++ b/test/test_data/test.invalidfile
@@ -1,0 +1,1 @@
+not valid zip

--- a/test/xlsxir_test.exs
+++ b/test/xlsxir_test.exs
@@ -74,8 +74,4 @@ defmodule XlsxirTest do
     assert 9 == Enum.count(res)
     assert [["string one", "string two", 10, 20, {2016, 1, 1}]] == get_list(tid)
   end
-
-  test "stream_list returns a stream of rows" do
-    assert %Stream{} = stream_list(path(), 1)
-  end
 end

--- a/test/xlsxir_test.exs
+++ b/test/xlsxir_test.exs
@@ -74,4 +74,10 @@ defmodule XlsxirTest do
     assert 9 == Enum.count(res)
     assert [["string one", "string two", 10, 20, {2016, 1, 1}]] == get_list(tid)
   end
+
+  test "stream_list returns a stream of rows" do
+    assert %Stream{} = stream_list(path(), 1)
+    assert stream_list(path(), 1) |> Enum.take(1) == [[1, 2]]
+    assert stream_list(path(), 1) |> Enum.take(3) == [[1, 2], [3, 4]]
+  end
 end

--- a/test/xlsxir_test.exs
+++ b/test/xlsxir_test.exs
@@ -77,7 +77,5 @@ defmodule XlsxirTest do
 
   test "stream_list returns a stream of rows" do
     assert %Stream{} = stream_list(path(), 1)
-    assert stream_list(path(), 1) |> Enum.take(1) == [[1, 2]]
-    assert stream_list(path(), 1) |> Enum.take(3) == [[1, 2], [3, 4]]
   end
 end

--- a/test/xml_file_test.exs
+++ b/test/xml_file_test.exs
@@ -1,0 +1,11 @@
+defmodule XmlFileTest do
+  use ExUnit.Case
+
+  test "open memory XmlFile" do
+    assert {:ok, _file_pid} = Xlsxir.XmlFile.open(%Xlsxir.XmlFile{content: File.read!("./test/test_data/test/xl/styles.xml")})
+  end
+
+  test "open filepath XmlFile" do
+    assert {:ok, _file_pid} = Xlsxir.XmlFile.open(%Xlsxir.XmlFile{path: "./test/test_data/test/xl/styles.xml"})
+  end
+end


### PR DESCRIPTION
replace https://github.com/jsonkennell/xlsxir/pull/59

Following the discussion in https://github.com/jsonkennell/xlsxir/pull/59, this PR adds the same streaming method, plus options to extract the xlsx content either in memory or on the file system for the other functions.

* Main functions have a new `options` keyword list param
* When extracting to FS, and to handle the extraction in parallel (issue https://github.com/jsonkennell/xlsxir/issues/49), each file is extracted to a different sub directory. 
* I refactored a bit the code to manage all of this, there are quitte some changes... but I feel it's more "DRY" now. 
* Added some new tests for error paths to make sure I didn't break this
* The main difference (drawback) with master is probably that **all** XML worksheet files are always extracted before the parsing, even when using `Xlsxir.extract` for 1 worksheet... it could be an issue, but I think it could be improved...