### PR TITLE
Fix ConvertDate.from_serial using :calendar

### DIFF
--- a/lib/xlsxir/convert_date.ex
+++ b/lib/xlsxir/convert_date.ex
@@ -28,68 +28,15 @@ defmodule Xlsxir.ConvertDate do
                              |> round
                   end
 
-    f_serial
-    |> process_serial_int
-    |> determine_year
-    |> determine_month_and_day
+    # Convert to gregorian days and get date from that
+    f_serial - 2 +               # adjust two days for first and last day since base year
+    date_to_days({1900, 1, 1})   # Add days in base year 1900
+    |> days_to_date
   end
 
-  defp process_serial_int(serial_int) do
-    year = serial_int
-           |> Kernel./(365)
-           |> Float.floor
-           |> Kernel.+(1900)
-           |> round
+  defp date_to_days(date), do: :calendar.date_to_gregorian_days(date)
 
-    serial_int = if serial_int >= 60 && serial_int <= 364, do: serial_int - 1, else: serial_int
-
-    days  = serial_int
-            |> rem(365)
-            |> Kernel.-(
-                        serial_int
-                        |> Kernel./(365)
-                        |> Float.floor
-                        |> Kernel./(4)
-                        |> Float.ceil
-                       )
-
-    {year, days}
-  end
-
-  defp determine_year({year, days}) do
-    if days <= 0, do: {year - 1, days}, else: {year, days}
-  end
-
-  defp determine_month_and_day({year, days}) do
-    l = if :calendar.is_leap_year(year), do: 1, else: 0
-
-
-    {month, day} = if days <= 0 do
-                     {12, 31 + days}
-                   else
-                     process_days(days, l)
-                   end
-
-    {year, month, round(day)}
-  end
-
-  defp process_days(days, l) do
-    cond do
-      days <= 31      -> {1, days}
-      days <= 59 + l  -> {2, days - 31}
-      days <= 90 + l  -> {3, days - 59 - l}
-      days <= 120 + l -> {4, days - 90 - l}
-      days <= 151 + l -> {5, days - 120 - l}
-      days <= 181 + l -> {6, days - 151 - l}
-      days <= 212 + l -> {7, days - 181 - l}
-      days <= 243 + l -> {8, days - 212 - l}
-      days <= 273 + l -> {9, days - 243 - l}
-      days <= 304 + l -> {10, days - 273 - l}
-      days <= 334 + l -> {11, days - 304 - l}
-      days <= 365 + l -> {12, days - 334 - l}
-      true            -> raise "Invalid Excel serial date."
-    end
-  end
+  defp days_to_date(days), do: :calendar.gregorian_days_to_date(days)
 
   @doc """
   Converts extracted number in `char_list` format to either `integer` or `float`.

--- a/test/convert_date_test.exs
+++ b/test/convert_date_test.exs
@@ -27,7 +27,7 @@ defmodule ConvertDateTest do
     assert Enum.map(test_one_data(), &from_serial/1) == test_one_results()
   end
 
-  def test_two_data(), do: ['42035', '42063', '42094', '42124', '42155', '42185', '42216', '42247', '42277', '42308', '42338', '42369']
+  def test_two_data(), do: ['42035', '42063', '42094', '42124', '42155', '42185', '42216', '42247', '42277', '42308', '42338', '42369', '44530']
 
   def test_two_results() do 
     [
@@ -42,11 +42,12 @@ defmodule ConvertDateTest do
       {2015,9,30},
       {2015,10,31},
       {2015,11,30},
-      {2015,12,31}
+      {2015,12,31},
+      {2021,11,30}
     ]
   end
 
-  test "last day of every month in non-leap year (2015)" do
+  test "last day of every month in non-leap year (2015, 2021)" do
     assert Enum.map(test_two_data(), &from_serial/1) == test_two_results()
   end
 


### PR DESCRIPTION
The date 2021-11-30 fails to be properly converted from Excel.
A test case is added for this date.

Fix is to use gregorian days since 1900 and :calendar module.