### PR TITLE
Fix get_cell returns nil for non-existent cells

### DIFF
--- a/lib/xlsxir.ex
+++ b/lib/xlsxir.ex
@@ -399,12 +399,12 @@ defmodule Xlsxir do
   defp do_get_cell(cell_ref, table_id) do
     [[row_num]] = ~r/\d+/ |> Regex.scan(cell_ref)
     row_num     = row_num |> String.to_integer
-    case :ets.match(table_id, {row_num, :"$1"}) do
-      [[row]] -> row
-                  |> Enum.filter(fn [ref, _val] -> ref == cell_ref end)
-                  |> List.first
-                  |> Enum.at(1)
-      _       -> nil
+
+    with [[row]] <- :ets.match(table_id, {row_num, :"$1"}),
+         [^cell_ref, value] <- Enum.find(row, fn [ref, _val] -> ref == cell_ref end) do
+      value
+    else
+      _ -> nil
     end
   end
 

--- a/test/xlsxir_test.exs
+++ b/test/xlsxir_test.exs
@@ -56,8 +56,9 @@ defmodule XlsxirTest do
   end
 
   test "get_cell returns nil for non-existent cells" do
-    {:ok, pid} = extract(path(), 3)
-    assert get_cell(pid, "A1") == nil
+    {:ok, pid} = extract(path(), 0)
+    assert get_cell(pid, "A2") == nil
+    assert get_cell(pid, "F1") == nil
     close(pid)
   end
 


### PR DESCRIPTION
this PR fixes the following use case

excel file:
```
B1 -> "some value"
```
`get_cell(table_id, "A1")` should return nil instead of raise